### PR TITLE
Make ffmpeg an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/tonarino/shadergarden"
 homepage = "https://blog.tonari.no/shadergarden"
 keywords = ["shader", "glsl", "lisp", "reload", "garden"]
 
+[features]
+default = ["ffmpeg"]
+ffmpeg = ["ffmpeg-next"]
+
 [dependencies]
 glium = "0.30.2"
 image = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ image = "0.23"
 notify = "5.0.0-pre.12"
 lexpr = "0.2.6"
 include_dir = "0.6"
-ffmpeg-next = "4.4"
+ffmpeg-next = { version = "4.4", optional = true }
 structopt = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub use include_dir;
 pub use notify;
 
 pub mod graph;
+#[cfg(feature = "ffmpeg")]
 pub mod input;
 pub mod lisp;
 pub mod map;

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,8 +180,12 @@ fn render(render: Render) {
     eprintln!("[info] Built initial graph");
 
     // build a table of textures
+    #[cfg(feature = "ffmpeg")]
     let mut input_textures =
         util::input_textures(&display, &inputs, args.width, args.height);
+
+    #[cfg(not(feature = "ffmpeg"))]
+    assert!(inputs.is_empty(), "Inputs are not supported when running without ffmpeg");
 
     eprintln!("[info] Starting Render...");
 
@@ -204,6 +208,11 @@ fn render(render: Render) {
             eprintln!("[fatal] Graph has invalid output signature.");
             panic!();
         };
+
+        #[cfg(not(feature = "ffmpeg"))]
+        assert!(input_nodes.is_empty());
+
+        #[cfg(feature = "ffmpeg")]
         assert_eq!(
             input_nodes.len(),
             input_textures.len(),
@@ -212,6 +221,8 @@ fn render(render: Render) {
 
         // render the shader graph, display the primary output
         let mut input_map = BTreeMap::new();
+
+        #[cfg(feature = "ffmpeg")]
         for (node_id, texture) in input_nodes.iter().zip(input_textures.iter_mut()) {
             input_map.insert(*node_id, texture.next_frame());
         }
@@ -269,8 +280,12 @@ fn run(args: Run) {
     eprintln!("[info] Built initial graph");
 
     // build a table of textures
+    #[cfg(feature = "ffmpeg")]
     let mut input_textures =
         util::input_textures(&display, &inputs, args.width, args.height);
+
+    #[cfg(not(feature = "ffmpeg"))]
+    assert!(inputs.is_empty(), "Inputs are not supported when running without ffmpeg");
 
     eprintln!("[info] Starting...");
 
@@ -298,6 +313,11 @@ fn run(args: Run) {
             eprintln!("[fatal] Graph has invalid output signature.");
             panic!();
         };
+
+        #[cfg(not(feature = "ffmpeg"))]
+        assert!(input_nodes.is_empty());
+
+        #[cfg(feature = "ffmpeg")]
         assert_eq!(
             input_nodes.len(),
             input_textures.len(),
@@ -306,9 +326,12 @@ fn run(args: Run) {
 
         // render the shader graph, display the primary output
         let mut input_map = BTreeMap::new();
+
+        #[cfg(feature = "ffmpeg")]
         for (node_id, texture) in input_nodes.iter().zip(input_textures.iter_mut()) {
             input_map.insert(*node_id, texture.next_frame());
         }
+
         let output_map = graph.forward(input_map);
 
         // set up the draw target and draw

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -33,6 +33,7 @@ use glium::{
     VertexBuffer,
 };
 
+#[cfg(feature = "ffmpeg")]
 use crate::input::FrameStream;
 
 #[derive(Copy, Clone)]
@@ -147,6 +148,7 @@ pub fn compile_shader(
         .map_err(|e| format!("{}", e))
 }
 
+#[cfg(feature = "ffmpeg")]
 pub fn input_textures(
     display: &Display,
     inputs: &[PathBuf],


### PR DESCRIPTION
This makes ffmpeg an optional dependency (enabled by default) so that shadergarden is easier to install on more platforms. This should work as a temporary solution to #9; the tradeoff is not being able to pass input into graphs.